### PR TITLE
Add get/set array operations to `ByteOps`

### DIFF
--- a/byteops-unsigned/src/main/java/com/digitalpetri/util/UnsignedByteOps.java
+++ b/byteops-unsigned/src/main/java/com/digitalpetri/util/UnsignedByteOps.java
@@ -74,6 +74,74 @@ public final class UnsignedByteOps<T> implements ByteOps<T> {
   }
 
   /**
+   * Get the {@link UByte} array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to get the value from.
+   * @param index the index into {@code bytes} to get the value at.
+   * @param length the length of the array.
+   * @return the UByte array at the given {@code index}.
+   */
+  public UByte[] getUByteArray(T bytes, int index, int length) {
+    byte[] byteArray = delegate.getByteArray(bytes, index, length);
+    UByte[] uByteArray = new UByte[byteArray.length];
+    for (int i = 0; i < byteArray.length; i++) {
+      uByteArray[i] = UByte.valueOf(byteArray[i]);
+    }
+    return uByteArray;
+  }
+
+  /**
+   * Get the {@link UShort} array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to get the value from.
+   * @param index the index into {@code bytes} to get the value at.
+   * @param length the length of the array.
+   * @return the UShort array at the given {@code index}.
+   */
+  public UShort[] getUShortArray(T bytes, int index, int length) {
+    short[] shortArray = delegate.getShortArray(bytes, index, length);
+    UShort[] uShortArray = new UShort[shortArray.length];
+    for (int i = 0; i < shortArray.length; i++) {
+      uShortArray[i] = UShort.valueOf(shortArray[i]);
+    }
+    return uShortArray;
+  }
+
+  /**
+   * Get the {@link UInteger} array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to get the value from.
+   * @param index the index into {@code bytes} to get the value at.
+   * @param length the length of the array.
+   * @return the UInteger array at the given {@code index}.
+   */
+  public UInteger[] getUIntArray(T bytes, int index, int length) {
+    int[] intArray = delegate.getIntArray(bytes, index, length);
+    UInteger[] uIntArray = new UInteger[intArray.length];
+    for (int i = 0; i < intArray.length; i++) {
+      uIntArray[i] = UInteger.valueOf(intArray[i]);
+    }
+    return uIntArray;
+  }
+
+  /**
+   * Get the {@link ULong} array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to get the value from.
+   * @param index the index into {@code bytes} to get the value at.
+   * @param length the length of the array.
+   * @return the ULong array at the given {@code index}.
+   */
+  public ULong[] getULongArray(T bytes, int index, int length) {
+    long[] longArray = delegate.getLongArray(bytes, index, length);
+    ULong[] uLongArray = new ULong[longArray.length];
+    for (int i = 0; i < longArray.length; i++) {
+      uLongArray[i] = ULong.valueOf(longArray[i]);
+    }
+    return uLongArray;
+  }
+
+  /**
    * Set the {@link UByte} value at the given {@code index} in {@code bytes}.
    *
    * @param bytes the bytes to set the value in.
@@ -115,6 +183,66 @@ public final class UnsignedByteOps<T> implements ByteOps<T> {
    */
   public void setULong(T bytes, int index, ULong value) {
     setLong(bytes, index, value.longValue());
+  }
+
+  /**
+   * Set the {@link UByte} array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to set the values in.
+   * @param index the index into {@code bytes} to set the values at.
+   * @param values the UByte array to set.
+   */
+  public void setUByteArray(T bytes, int index, UByte[] values) {
+    byte[] byteArray = new byte[values.length];
+    for (int i = 0; i < values.length; i++) {
+      byteArray[i] = values[i].byteValue();
+    }
+    delegate.setByteArray(bytes, index, byteArray);
+  }
+
+  /**
+   * Set the {@link UShort} array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to set the values in.
+   * @param index the index into {@code bytes} to set the values at.
+   * @param values the UShort array to set.
+   */
+  public void setUShortArray(T bytes, int index, UShort[] values) {
+    short[] shortArray = new short[values.length];
+    for (int i = 0; i < values.length; i++) {
+      shortArray[i] = values[i].shortValue();
+    }
+    delegate.setShortArray(bytes, index, shortArray);
+  }
+
+  /**
+   * Set the {@link UInteger} array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to set the values in.
+   * @param index the index into {@code bytes} to set the values at.
+   * @param values the UInteger array to set.
+   */
+  public void setUIntArray(T bytes, int index, UInteger[] values) {
+    int[] intArray = new int[values.length];
+    for (int i = 0; i < values.length; i++) {
+      intArray[i] = values[i].intValue();
+    }
+    delegate.setIntArray(bytes, index, intArray);
+  }
+
+  /**
+   * Set the {@link ULong} array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to set the values in.
+   * @param index the index into {@code bytes} to set the values at.
+   * @param values the ULong array to set.
+   */
+  public void setULongArray(T bytes, int index, ULong[] values) {
+    long[] longArray = new long[values.length];
+    for (int i = 0; i < values.length; i++) {
+      longArray[i] = values[i].longValue();
+    }
+    delegate.setLongArray(bytes, index, longArray);
   }
 
   // region ByteOps delegated methods

--- a/byteops-unsigned/src/main/java/com/digitalpetri/util/UnsignedByteOps.java
+++ b/byteops-unsigned/src/main/java/com/digitalpetri/util/UnsignedByteOps.java
@@ -117,7 +117,7 @@ public final class UnsignedByteOps<T> implements ByteOps<T> {
     setLong(bytes, index, value.longValue());
   }
 
-  //region ByteOps delegated methods
+  // region ByteOps delegated methods
 
   @Override
   public boolean getBoolean(T bytes, int index) {
@@ -155,6 +155,41 @@ public final class UnsignedByteOps<T> implements ByteOps<T> {
   }
 
   @Override
+  public boolean[] getBooleanArray(T bytes, int index, int length) {
+    return delegate.getBooleanArray(bytes, index, length);
+  }
+
+  @Override
+  public byte[] getByteArray(T bytes, int index, int length) {
+    return delegate.getByteArray(bytes, index, length);
+  }
+
+  @Override
+  public short[] getShortArray(T bytes, int index, int length) {
+    return delegate.getShortArray(bytes, index, length);
+  }
+
+  @Override
+  public int[] getIntArray(T bytes, int index, int length) {
+    return delegate.getIntArray(bytes, index, length);
+  }
+
+  @Override
+  public long[] getLongArray(T bytes, int index, int length) {
+    return delegate.getLongArray(bytes, index, length);
+  }
+
+  @Override
+  public float[] getFloatArray(T bytes, int index, int length) {
+    return delegate.getFloatArray(bytes, index, length);
+  }
+
+  @Override
+  public double[] getDoubleArray(T bytes, int index, int length) {
+    return delegate.getDoubleArray(bytes, index, length);
+  }
+
+  @Override
   public void setBoolean(T bytes, int index, boolean value) {
     delegate.setBoolean(bytes, index, value);
   }
@@ -189,6 +224,41 @@ public final class UnsignedByteOps<T> implements ByteOps<T> {
     delegate.setDouble(bytes, index, value);
   }
 
-  //endregion
+  @Override
+  public void setBooleanArray(T bytes, int index, boolean[] values) {
+    delegate.setBooleanArray(bytes, index, values);
+  }
+
+  @Override
+  public void setByteArray(T bytes, int index, byte[] values) {
+    delegate.setByteArray(bytes, index, values);
+  }
+
+  @Override
+  public void setShortArray(T bytes, int index, short[] values) {
+    delegate.setShortArray(bytes, index, values);
+  }
+
+  @Override
+  public void setIntArray(T bytes, int index, int[] values) {
+    delegate.setIntArray(bytes, index, values);
+  }
+
+  @Override
+  public void setLongArray(T bytes, int index, long[] values) {
+    delegate.setLongArray(bytes, index, values);
+  }
+
+  @Override
+  public void setFloatArray(T bytes, int index, float[] values) {
+    delegate.setFloatArray(bytes, index, values);
+  }
+
+  @Override
+  public void setDoubleArray(T bytes, int index, double[] values) {
+    delegate.setDoubleArray(bytes, index, values);
+  }
+
+  // endregion
 
 }

--- a/byteops-unsigned/src/test/java/com/digitalpetri/util/UnsignedByteOpsTest.java
+++ b/byteops-unsigned/src/test/java/com/digitalpetri/util/UnsignedByteOpsTest.java
@@ -15,10 +15,24 @@ class UnsignedByteOpsTest {
     ByteOps<byte[]> ops = ByteArrayByteOps.BIG_ENDIAN;
     UnsignedByteOps<byte[]> unsignedOps = UnsignedByteOps.of(ops);
 
-    byte[] bytes = new byte[]{(byte) 0xff};
+    byte[] bytes = new byte[] {(byte) 0xff};
     UByte uByte = unsignedOps.getUByte(bytes, 0);
 
     assertEquals(UByte.valueOf((byte) 0xff), uByte);
+  }
+
+  @Test
+  void getUByteArray() {
+    ByteOps<byte[]> ops = ByteArrayByteOps.BIG_ENDIAN;
+    UnsignedByteOps<byte[]> unsignedOps = UnsignedByteOps.of(ops);
+
+    byte[] bytes = new byte[] {(byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04};
+    UByte[] uBytes = unsignedOps.getUByteArray(bytes, 0, 4);
+
+    assertEquals(UByte.valueOf((byte) 0x01), uBytes[0]);
+    assertEquals(UByte.valueOf((byte) 0x02), uBytes[1]);
+    assertEquals(UByte.valueOf((byte) 0x03), uBytes[2]);
+    assertEquals(UByte.valueOf((byte) 0x04), uBytes[3]);
   }
 
   @Test
@@ -34,14 +48,52 @@ class UnsignedByteOpsTest {
   }
 
   @Test
+  void setUByteArray() {
+    ByteOps<byte[]> ops = ByteArrayByteOps.BIG_ENDIAN;
+    UnsignedByteOps<byte[]> unsignedOps = UnsignedByteOps.of(ops);
+
+    byte[] bytes = new byte[4];
+    unsignedOps.setUByteArray(
+        bytes,
+        0,
+        new UByte[] {
+          UByte.valueOf((byte) 0x01),
+          UByte.valueOf((byte) 0x02),
+          UByte.valueOf((byte) 0x03),
+          UByte.valueOf((byte) 0x04)
+        });
+
+    assertEquals((byte) 0x01, bytes[0]);
+    assertEquals((byte) 0x02, bytes[1]);
+    assertEquals((byte) 0x03, bytes[2]);
+    assertEquals((byte) 0x04, bytes[3]);
+    assertEquals(0x01, unsignedOps.getUByte(bytes, 0).intValue());
+    assertEquals(0x02, unsignedOps.getUByte(bytes, 1).intValue());
+    assertEquals(0x03, unsignedOps.getUByte(bytes, 2).intValue());
+    assertEquals(0x04, unsignedOps.getUByte(bytes, 3).intValue());
+  }
+
+  @Test
   void getUShort() {
     ByteOps<byte[]> ops = ByteArrayByteOps.BIG_ENDIAN;
     UnsignedByteOps<byte[]> unsignedOps = UnsignedByteOps.of(ops);
 
-    byte[] bytes = new byte[]{(byte) 0xff, (byte) 0xff};
+    byte[] bytes = new byte[] {(byte) 0xff, (byte) 0xff};
     UShort uShort = unsignedOps.getUShort(bytes, 0);
 
     assertEquals(UShort.valueOf((short) 0xffff), uShort);
+  }
+
+  @Test
+  void getUShortArray() {
+    ByteOps<byte[]> ops = ByteArrayByteOps.BIG_ENDIAN;
+    UnsignedByteOps<byte[]> unsignedOps = UnsignedByteOps.of(ops);
+
+    byte[] bytes = new byte[] {(byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04};
+    UShort[] uShorts = unsignedOps.getUShortArray(bytes, 0, 2);
+
+    assertEquals(UShort.valueOf((short) 0x0102), uShorts[0]);
+    assertEquals(UShort.valueOf((short) 0x0304), uShorts[1]);
   }
 
   @Test
@@ -58,14 +110,48 @@ class UnsignedByteOpsTest {
   }
 
   @Test
+  void setUShortArray() {
+    ByteOps<byte[]> ops = ByteArrayByteOps.BIG_ENDIAN;
+    UnsignedByteOps<byte[]> unsignedOps = UnsignedByteOps.of(ops);
+
+    byte[] bytes = new byte[4];
+    unsignedOps.setUShortArray(
+        bytes, 0, new UShort[] {UShort.valueOf((short) 0x0102), UShort.valueOf((short) 0x0304)});
+
+    assertEquals((byte) 0x01, bytes[0]);
+    assertEquals((byte) 0x02, bytes[1]);
+    assertEquals((byte) 0x03, bytes[2]);
+    assertEquals((byte) 0x04, bytes[3]);
+    assertEquals(0x0102, unsignedOps.getUShort(bytes, 0).intValue());
+    assertEquals(0x0304, unsignedOps.getUShort(bytes, 2).intValue());
+  }
+
+  @Test
   void getUInt() {
     ByteOps<byte[]> ops = ByteArrayByteOps.BIG_ENDIAN;
     UnsignedByteOps<byte[]> unsignedOps = UnsignedByteOps.of(ops);
 
-    byte[] bytes = new byte[]{(byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff};
+    byte[] bytes = new byte[] {(byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff};
     UInteger uInteger = unsignedOps.getUInt(bytes, 0);
 
     assertEquals(UInteger.valueOf(0xffffffffL), uInteger);
+  }
+
+  @Test
+  void getUIntArray() {
+    ByteOps<byte[]> ops = ByteArrayByteOps.BIG_ENDIAN;
+    UnsignedByteOps<byte[]> unsignedOps = UnsignedByteOps.of(ops);
+
+    byte[] bytes =
+        new byte[] {
+          (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
+          (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08
+        };
+
+    UInteger[] uInts = unsignedOps.getUIntArray(bytes, 0, 2);
+
+    assertEquals(UInteger.valueOf(0x01020304), uInts[0]);
+    assertEquals(UInteger.valueOf(0x05060708), uInts[1]);
   }
 
   @Test
@@ -84,18 +170,59 @@ class UnsignedByteOpsTest {
   }
 
   @Test
+  void setUIntArray() {
+    ByteOps<byte[]> ops = ByteArrayByteOps.BIG_ENDIAN;
+    UnsignedByteOps<byte[]> unsignedOps = UnsignedByteOps.of(ops);
+
+    byte[] bytes = new byte[8];
+    unsignedOps.setUIntArray(
+        bytes, 0, new UInteger[] {UInteger.valueOf(0x01020304), UInteger.valueOf(0x05060708)});
+
+    assertEquals((byte) 0x01, bytes[0]);
+    assertEquals((byte) 0x02, bytes[1]);
+    assertEquals((byte) 0x03, bytes[2]);
+    assertEquals((byte) 0x04, bytes[3]);
+    assertEquals((byte) 0x05, bytes[4]);
+    assertEquals((byte) 0x06, bytes[5]);
+    assertEquals((byte) 0x07, bytes[6]);
+    assertEquals((byte) 0x08, bytes[7]);
+    assertEquals(0x01020304, unsignedOps.getUInt(bytes, 0).intValue());
+    assertEquals(0x05060708, unsignedOps.getUInt(bytes, 4).intValue());
+  }
+
+  @Test
   void getULong() {
     ByteOps<byte[]> ops = ByteArrayByteOps.BIG_ENDIAN;
     UnsignedByteOps<byte[]> unsignedOps = UnsignedByteOps.of(ops);
 
-    byte[] bytes = new byte[]{
-        (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
-        (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff
-    };
+    byte[] bytes =
+        new byte[] {
+          (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
+          (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff
+        };
 
     ULong uLong = unsignedOps.getULong(bytes, 0);
 
     assertEquals(ULong.valueOf(0xffffffffffffffffL), uLong);
+  }
+
+  @Test
+  void getULongArray() {
+    ByteOps<byte[]> ops = ByteArrayByteOps.BIG_ENDIAN;
+    UnsignedByteOps<byte[]> unsignedOps = UnsignedByteOps.of(ops);
+
+    byte[] bytes =
+        new byte[] {
+          (byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04,
+          (byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08,
+          (byte) 0x09, (byte) 0x0a, (byte) 0x0b, (byte) 0x0c,
+          (byte) 0x0d, (byte) 0x0e, (byte) 0x0f, (byte) 0x10
+        };
+
+    ULong[] uLongs = unsignedOps.getULongArray(bytes, 0, 2);
+
+    assertEquals(ULong.valueOf(0x0102030405060708L), uLongs[0]);
+    assertEquals(ULong.valueOf(0x090a0b0c0d0e0f10L), uLongs[1]);
   }
 
   @Test
@@ -117,4 +244,34 @@ class UnsignedByteOpsTest {
     assertEquals(0xffffffffffffffffL, unsignedOps.getULong(bytes, 0).longValue());
   }
 
+  @Test
+  void setULongArray() {
+    ByteOps<byte[]> ops = ByteArrayByteOps.BIG_ENDIAN;
+    UnsignedByteOps<byte[]> unsignedOps = UnsignedByteOps.of(ops);
+
+    byte[] bytes = new byte[16];
+    unsignedOps.setULongArray(
+        bytes,
+        0,
+        new ULong[] {ULong.valueOf(0x0102030405060708L), ULong.valueOf(0x090a0b0c0d0e0f10L)});
+
+    assertEquals((byte) 0x01, bytes[0]);
+    assertEquals((byte) 0x02, bytes[1]);
+    assertEquals((byte) 0x03, bytes[2]);
+    assertEquals((byte) 0x04, bytes[3]);
+    assertEquals((byte) 0x05, bytes[4]);
+    assertEquals((byte) 0x06, bytes[5]);
+    assertEquals((byte) 0x07, bytes[6]);
+    assertEquals((byte) 0x08, bytes[7]);
+    assertEquals((byte) 0x09, bytes[8]);
+    assertEquals((byte) 0x0a, bytes[9]);
+    assertEquals((byte) 0x0b, bytes[10]);
+    assertEquals((byte) 0x0c, bytes[11]);
+    assertEquals((byte) 0x0d, bytes[12]);
+    assertEquals((byte) 0x0e, bytes[13]);
+    assertEquals((byte) 0x0f, bytes[14]);
+    assertEquals((byte) 0x10, bytes[15]);
+    assertEquals(0x0102030405060708L, unsignedOps.getULong(bytes, 0).longValue());
+    assertEquals(0x090a0b0c0d0e0f10L, unsignedOps.getULong(bytes, 8).longValue());
+  }
 }

--- a/byteops/src/main/java/com/digitalpetri/util/AbstractByteOps.java
+++ b/byteops/src/main/java/com/digitalpetri/util/AbstractByteOps.java
@@ -71,6 +71,83 @@ public abstract class AbstractByteOps<T> implements ByteOps<T> {
   }
 
   @Override
+  public boolean[] getBooleanArray(T bytes, int index, int length) {
+    var value = new boolean[length];
+
+    for (int i = 0; i < length; i++) {
+      value[i] = getBoolean(bytes, index + i);
+    }
+
+    return value;
+  }
+
+  @Override
+  public byte[] getByteArray(T bytes, int index, int length) {
+    var value = new byte[length];
+
+    for (int i = 0; i < length; i++) {
+      value[i] = getByte(bytes, index + i);
+    }
+
+    return value;
+  }
+
+  @Override
+  public short[] getShortArray(T bytes, int index, int length) {
+    var value = new short[length];
+
+    for (int i = 0; i < length; i++) {
+      value[i] = getShort(bytes, index + i * 2);
+    }
+
+    return value;
+  }
+
+  @Override
+  public int[] getIntArray(T bytes, int index, int length) {
+    var value = new int[length];
+
+    for (int i = 0; i < length; i++) {
+      value[i] = getInt(bytes, index + i * 4);
+    }
+
+    return value;
+  }
+
+  @Override
+  public long[] getLongArray(T bytes, int index, int length) {
+    var value = new long[length];
+
+    for (int i = 0; i < length; i++) {
+      value[i] = getLong(bytes, index + i * 8);
+    }
+
+    return value;
+  }
+
+  @Override
+  public float[] getFloatArray(T bytes, int index, int length) {
+    var value = new float[length];
+
+    for (int i = 0; i < length; i++) {
+      value[i] = getFloat(bytes, index + i * 4);
+    }
+
+    return value;
+  }
+
+  @Override
+  public double[] getDoubleArray(T bytes, int index, int length) {
+    var value = new double[length];
+
+    for (int i = 0; i < length; i++) {
+      value[i] = getDouble(bytes, index + i * 8);
+    }
+
+    return value;
+  }
+
+  @Override
   public void setByte(T bytes, int index, byte value) {
     set(bytes, index, value);
   }
@@ -100,4 +177,52 @@ public abstract class AbstractByteOps<T> implements ByteOps<T> {
     setLong(bytes, index, Double.doubleToRawLongBits(value));
   }
 
+  @Override
+  public void setBooleanArray(T bytes, int index, boolean[] values) {
+    for (int i = 0; i < values.length; i++) {
+      setBoolean(bytes, index + i, values[i]);
+    }
+  }
+
+  @Override
+  public void setByteArray(T bytes, int index, byte[] values) {
+    for (int i = 0; i < values.length; i++) {
+      setByte(bytes, index + i, values[i]);
+    }
+  }
+
+  @Override
+  public void setShortArray(T bytes, int index, short[] values) {
+    for (int i = 0; i < values.length; i++) {
+      setShort(bytes, index + i * 2, values[i]);
+    }
+  }
+
+  @Override
+  public void setIntArray(T bytes, int index, int[] values) {
+    for (int i = 0; i < values.length; i++) {
+      setInt(bytes, index + i * 4, values[i]);
+    }
+  }
+
+  @Override
+  public void setLongArray(T bytes, int index, long[] values) {
+    for (int i = 0; i < values.length; i++) {
+      setLong(bytes, index + i * 8, values[i]);
+    }
+  }
+
+  @Override
+  public void setFloatArray(T bytes, int index, float[] values) {
+    for (int i = 0; i < values.length; i++) {
+      setFloat(bytes, index + i * 4, values[i]);
+    }
+  }
+
+  @Override
+  public void setDoubleArray(T bytes, int index, double[] values) {
+    for (int i = 0; i < values.length; i++) {
+      setDouble(bytes, index + i * 8, values[i]);
+    }
+  }
 }

--- a/byteops/src/main/java/com/digitalpetri/util/ByteOps.java
+++ b/byteops/src/main/java/com/digitalpetri/util/ByteOps.java
@@ -68,6 +68,76 @@ public interface ByteOps<T> {
   double getDouble(T bytes, int index);
 
   /**
+   * Get the boolean array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to get the value from.
+   * @param index the index into {@code bytes} to get the value at.
+   * @param length the length of the array.
+   * @return the boolean array at the given {@code index}.
+   */
+  boolean[] getBooleanArray(T bytes, int index, int length);
+
+  /**
+   * Get the byte array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to get the value from.
+   * @param index the index into {@code bytes} to get the value at.
+   * @param length the length of the array.
+   * @return the byte array at the given {@code index}.
+   */
+  byte[] getByteArray(T bytes, int index, int length);
+
+  /**
+   * Get the short array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to get the value from.
+   * @param index the index into {@code bytes} to get the value at.
+   * @param length the length of the array.
+   * @return the short array at the given {@code index}.
+   */
+  short[] getShortArray(T bytes, int index, int length);
+
+  /**
+   * Get the int array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to get the value from.
+   * @param index the index into {@code bytes} to get the value at.
+   * @param length the length of the array.
+   * @return the int array at the given {@code index}.
+   */
+  int[] getIntArray(T bytes, int index, int length);
+
+  /**
+   * Get the long array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to get the value from.
+   * @param index the index into {@code bytes} to get the value at.
+   * @param length the length of the array.
+   * @return the long array at the given {@code index}.
+   */
+  long[] getLongArray(T bytes, int index, int length);
+
+  /**
+   * Get the float array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to get the value from.
+   * @param index the index into {@code bytes} to get the value at.
+   * @param length the length of the array.
+   * @return the float array at the given {@code index}.
+   */
+  float[] getFloatArray(T bytes, int index, int length);
+
+  /**
+   * Get the double array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to get the value from.
+   * @param index the index into {@code bytes} to get the value at.
+   * @param length the length of the array.
+   * @return the double array at the given {@code index}.
+   */
+  double[] getDoubleArray(T bytes, int index, int length);
+
+  /**
    * Set the boolean value at the given {@code index} in {@code bytes}.
    *
    * <p>A false value is set as zero and a true value is set as one.
@@ -132,4 +202,66 @@ public interface ByteOps<T> {
    */
   void setDouble(T bytes, int index, double value);
 
+  /**
+   * Set the boolean array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to set the values in.
+   * @param index the index into {@code bytes} to set the values at.
+   * @param values the boolean array to set.
+   */
+  void setBooleanArray(T bytes, int index, boolean[] values);
+
+  /**
+   * Set the byte array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to set the values in.
+   * @param index the index into {@code bytes} to set the values at.
+   * @param values the byte array to set.
+   */
+  void setByteArray(T bytes, int index, byte[] values);
+
+  /**
+   * Set the short array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to set the values in.
+   * @param index the index into {@code bytes} to set the values at.
+   * @param values the short array to set.
+   */
+  void setShortArray(T bytes, int index, short[] values);
+
+  /**
+   * Set the int array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to set the values in.
+   * @param index the index into {@code bytes} to set the values at.
+   * @param values the int array to set.
+   */
+  void setIntArray(T bytes, int index, int[] values);
+
+  /**
+   * Set the long array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to set the values in.
+   * @param index the index into {@code bytes} to set the values at.
+   * @param values the long array to set.
+   */
+  void setLongArray(T bytes, int index, long[] values);
+
+  /**
+   * Set the float array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to set the values in.
+   * @param index the index into {@code bytes} to set the values at.
+   * @param values the float array to set.
+   */
+  void setFloatArray(T bytes, int index, float[] values);
+
+  /**
+   * Set the double array at the given {@code index} in {@code bytes}.
+   *
+   * @param bytes the bytes to set the values in.
+   * @param index the index into {@code bytes} to set the values at.
+   * @param values the double array to set.
+   */
+  void setDoubleArray(T bytes, int index, double[] values);
 }

--- a/byteops/src/test/java/com/digitalpetri/util/AbstractByteOpsTest.java
+++ b/byteops/src/test/java/com/digitalpetri/util/AbstractByteOpsTest.java
@@ -1,5 +1,6 @@
 package com.digitalpetri.util;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,155 +22,414 @@ abstract class AbstractByteOpsTest<T> {
 
     private final ByteOps<T> byteOps = getByteOps(ByteOrder.BIG_ENDIAN);
 
-    @Test
-    void getBoolean() {
-      assertFalse(byteOps.getBoolean(getBytes(new byte[]{0x00}), 0));
-      assertTrue(byteOps.getBoolean(getBytes(new byte[]{0x01}), 0));
+    @Nested
+    class ScalarGet {
+
+      @Test
+      void getBoolean() {
+        assertFalse(byteOps.getBoolean(getBytes(new byte[] {0x00}), 0));
+        assertTrue(byteOps.getBoolean(getBytes(new byte[] {0x01}), 0));
+      }
+
+      @Test
+      void getByte() {
+        T bytes = getBytes(new byte[] {0x00});
+
+        byte b = byteOps.getByte(bytes, 0);
+
+        assertEquals(0x00, b);
+      }
+
+      @Test
+      void getShort() {
+        T bytes = getBytes(new byte[] {0x00, 0x01});
+
+        short s = byteOps.getShort(bytes, 0);
+
+        assertEquals(0x0001, s);
+      }
+
+      @Test
+      void getInt() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03});
+
+        int i = byteOps.getInt(bytes, 0);
+
+        assertEquals(0x0001_0203, i);
+      }
+
+      @Test
+      void getLong() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
+
+        long l = byteOps.getLong(bytes, 0);
+
+        assertEquals(0x0001_0203_0405_0607L, l);
+      }
+
+      @Test
+      void getFloat() {
+        T bytes = getBytes(new byte[] {0x3F, (byte) 0x80, 0x00, 0x00});
+
+        float f = byteOps.getFloat(bytes, 0);
+
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), f);
+      }
+
+      @Test
+      void getDouble() {
+        T bytes = getBytes(new byte[] {0x3F, (byte) 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+
+        double d = byteOps.getDouble(bytes, 0);
+
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), d);
+      }
     }
 
-    @Test
-    void setBoolean() {
-      T bytes = getBytes(new byte[]{0x00});
+    @Nested
+    class ScalarSet {
 
-      byteOps.setBoolean(bytes, 0, true);
+      @Test
+      void setBoolean() {
+        T bytes = getBytes(new byte[] {0x00});
 
-      assertTrue(byteOps.getBoolean(bytes, 0));
+        byteOps.setBoolean(bytes, 0, true);
+
+        assertTrue(byteOps.getBoolean(bytes, 0));
+      }
+
+      @Test
+      void setByte() {
+        T bytes = getBytes(new byte[] {0x00});
+
+        byteOps.setByte(bytes, 0, (byte) 0x01);
+
+        assertEquals(0x01, byteOps.getByte(bytes, 0));
+      }
+
+      @Test
+      void setShort() {
+        T bytes = getBytes(new byte[] {0x00, 0x00});
+
+        byteOps.setShort(bytes, 0, (short) 0x0102);
+
+        assertEquals(0x01, byteOps.getByte(bytes, 0));
+        assertEquals(0x02, byteOps.getByte(bytes, 1));
+        assertEquals(0x0102, byteOps.getShort(bytes, 0));
+      }
+
+      @Test
+      void setInt() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, 0x00, 0x00});
+
+        byteOps.setInt(bytes, 0, 0x0102_0304);
+
+        assertEquals(0x01, byteOps.getByte(bytes, 0));
+        assertEquals(0x02, byteOps.getByte(bytes, 1));
+        assertEquals(0x03, byteOps.getByte(bytes, 2));
+        assertEquals(0x04, byteOps.getByte(bytes, 3));
+        assertEquals(0x0102_0304, byteOps.getInt(bytes, 0));
+      }
+
+      @Test
+      void setLong() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+
+        byteOps.setLong(bytes, 0, 0x0102_0304_0506_0708L);
+
+        assertEquals(0x01, byteOps.getByte(bytes, 0));
+        assertEquals(0x02, byteOps.getByte(bytes, 1));
+        assertEquals(0x03, byteOps.getByte(bytes, 2));
+        assertEquals(0x04, byteOps.getByte(bytes, 3));
+        assertEquals(0x05, byteOps.getByte(bytes, 4));
+        assertEquals(0x06, byteOps.getByte(bytes, 5));
+        assertEquals(0x07, byteOps.getByte(bytes, 6));
+        assertEquals(0x08, byteOps.getByte(bytes, 7));
+        assertEquals(0x0102_0304_0506_0708L, byteOps.getLong(bytes, 0));
+      }
+
+      @Test
+      void setFloat() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, 0x00, 0x00});
+
+        byteOps.setFloat(bytes, 0, Float.intBitsToFloat(0x3F80_0000));
+
+        assertEquals(0x3F, byteOps.getByte(bytes, 0));
+        assertEquals((byte) 0x80, byteOps.getByte(bytes, 1));
+        assertEquals(0x00, byteOps.getByte(bytes, 2));
+        assertEquals(0x00, byteOps.getByte(bytes, 3));
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), byteOps.getFloat(bytes, 0));
+      }
+
+      @Test
+      void setDouble() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+
+        byteOps.setDouble(bytes, 0, Double.longBitsToDouble(0x3FF0_0000_0000_0000L));
+
+        assertEquals(0x3F, byteOps.getByte(bytes, 0));
+        assertEquals((byte) 0xF0, byteOps.getByte(bytes, 1));
+        assertEquals(0x00, byteOps.getByte(bytes, 2));
+        assertEquals(0x00, byteOps.getByte(bytes, 3));
+        assertEquals(0x00, byteOps.getByte(bytes, 4));
+        assertEquals(0x00, byteOps.getByte(bytes, 5));
+        assertEquals(0x00, byteOps.getByte(bytes, 6));
+        assertEquals(0x00, byteOps.getByte(bytes, 7));
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), byteOps.getDouble(bytes, 0));
+      }
     }
 
-    @Test
-    void getByte() {
-      T bytes = getBytes(new byte[]{0x00});
+    @Nested
+    class ArrayGet {
 
-      byte b = byteOps.getByte(bytes, 0);
+      @Test
+      void getBooleanArray() {
+        T bytes = getBytes(new byte[] {0x00, 0x01});
 
-      assertEquals(0x00, b);
+        boolean[] bs = byteOps.getBooleanArray(bytes, 0, 2);
+
+        assertFalse(bs[0]);
+        assertTrue(bs[1]);
+        assertArrayEquals(new boolean[] {false, true}, bs);
+      }
+
+      @Test
+      void getByteArray() {
+        T bytes = getBytes(new byte[] {0x00, 0x01});
+
+        byte[] bs = byteOps.getByteArray(bytes, 0, 2);
+
+        assertEquals(0x00, bs[0]);
+        assertEquals(0x01, bs[1]);
+        assertArrayEquals(new byte[] {0x00, 0x01}, bs);
+      }
+
+      @Test
+      void getShortArray() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03});
+
+        short[] ss = byteOps.getShortArray(bytes, 0, 2);
+
+        assertEquals(0x0001, ss[0]);
+        assertEquals(0x0203, ss[1]);
+        assertArrayEquals(new short[] {0x0001, 0x0203}, ss);
+      }
+
+      @Test
+      void getIntArray() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
+
+        int[] is = byteOps.getIntArray(bytes, 0, 2);
+
+        assertEquals(0x0001_0203, is[0]);
+        assertEquals(0x0405_0607, is[1]);
+        assertArrayEquals(new int[] {0x0001_0203, 0x0405_0607}, is);
+      }
+
+      @Test
+      void getLongArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                  0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
+                });
+
+        long[] ls = byteOps.getLongArray(bytes, 0, 2);
+
+        assertEquals(0x0001_0203_0405_0607L, ls[0]);
+        assertEquals(0x0809_0A0B_0C0D_0E0FL, ls[1]);
+        assertArrayEquals(new long[] {0x0001_0203_0405_0607L, 0x0809_0A0B_0C0D_0E0FL}, ls);
+      }
+
+      @Test
+      void getFloatArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x3F, (byte) 0x80, 0x00, 0x00,
+                  0x3F, (byte) 0x80, 0x00, 0x00
+                });
+
+        float[] fs = byteOps.getFloatArray(bytes, 0, 2);
+
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), fs[0]);
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), fs[1]);
+        assertArrayEquals(
+            new float[] {Float.intBitsToFloat(0x3F80_0000), Float.intBitsToFloat(0x3F80_0000)}, fs);
+      }
+
+      @Test
+      void getDoubleArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x3F, (byte) 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                  0x3F, (byte) 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+                });
+
+        double[] ds = byteOps.getDoubleArray(bytes, 0, 2);
+
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), ds[0]);
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), ds[1]);
+        assertArrayEquals(
+            new double[] {
+              Double.longBitsToDouble(0x3FF0_0000_0000_0000L),
+              Double.longBitsToDouble(0x3FF0_0000_0000_0000L)
+            },
+            ds);
+      }
     }
 
-    @Test
-    void setByte() {
-      T bytes = getBytes(new byte[]{0x00});
+    @Nested
+    class ArraySet {
 
-      byteOps.setByte(bytes, 0, (byte) 0x01);
+      @Test
+      void setBooleanArray() {
+        T bytes = getBytes(new byte[] {0x00, 0x00});
 
-      assertEquals(0x01, byteOps.getByte(bytes, 0));
+        byteOps.setBooleanArray(bytes, 0, new boolean[] {true, true});
+
+        assertTrue(byteOps.getBoolean(bytes, 0));
+        assertTrue(byteOps.getBoolean(bytes, 1));
+      }
+
+      @Test
+      void setByteArray() {
+        T bytes = getBytes(new byte[] {0x00, 0x00});
+
+        byteOps.setByteArray(bytes, 0, new byte[] {0x01, 0x02});
+
+        assertEquals(0x01, byteOps.getByte(bytes, 0));
+        assertEquals(0x02, byteOps.getByte(bytes, 1));
+      }
+
+      @Test
+      void setShortArray() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, 0x00, 0x00});
+
+        byteOps.setShortArray(bytes, 0, new short[] {0x0102, 0x0304});
+
+        assertEquals(0x01, byteOps.getByte(bytes, 0));
+        assertEquals(0x02, byteOps.getByte(bytes, 1));
+        assertEquals(0x03, byteOps.getByte(bytes, 2));
+        assertEquals(0x04, byteOps.getByte(bytes, 3));
+        assertEquals(0x0102, byteOps.getShort(bytes, 0));
+        assertEquals(0x0304, byteOps.getShort(bytes, 2));
+      }
+
+      @Test
+      void setIntArray() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+
+        byteOps.setIntArray(bytes, 0, new int[] {0x0102_0304, 0x0506_0708});
+
+        assertEquals(0x01, byteOps.getByte(bytes, 0));
+        assertEquals(0x02, byteOps.getByte(bytes, 1));
+        assertEquals(0x03, byteOps.getByte(bytes, 2));
+        assertEquals(0x04, byteOps.getByte(bytes, 3));
+        assertEquals(0x05, byteOps.getByte(bytes, 4));
+        assertEquals(0x06, byteOps.getByte(bytes, 5));
+        assertEquals(0x07, byteOps.getByte(bytes, 6));
+        assertEquals(0x08, byteOps.getByte(bytes, 7));
+        assertEquals(0x0102_0304, byteOps.getInt(bytes, 0));
+        assertEquals(0x0506_0708, byteOps.getInt(bytes, 4));
+      }
+
+      @Test
+      void setLongArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+                });
+
+        byteOps.setLongArray(bytes, 0, new long[] {0x0102_0304_0506_0708L, 0x090A_0B0C_0D0E_0F10L});
+
+        assertEquals(0x01, byteOps.getByte(bytes, 0));
+        assertEquals(0x02, byteOps.getByte(bytes, 1));
+        assertEquals(0x03, byteOps.getByte(bytes, 2));
+        assertEquals(0x04, byteOps.getByte(bytes, 3));
+        assertEquals(0x05, byteOps.getByte(bytes, 4));
+        assertEquals(0x06, byteOps.getByte(bytes, 5));
+        assertEquals(0x07, byteOps.getByte(bytes, 6));
+        assertEquals(0x08, byteOps.getByte(bytes, 7));
+        assertEquals(0x09, byteOps.getByte(bytes, 8));
+        assertEquals(0x0A, byteOps.getByte(bytes, 9));
+        assertEquals(0x0B, byteOps.getByte(bytes, 10));
+        assertEquals(0x0C, byteOps.getByte(bytes, 11));
+        assertEquals(0x0D, byteOps.getByte(bytes, 12));
+        assertEquals(0x0E, byteOps.getByte(bytes, 13));
+        assertEquals(0x0F, byteOps.getByte(bytes, 14));
+        assertEquals(0x10, byteOps.getByte(bytes, 15));
+        assertEquals(0x0102_0304_0506_0708L, byteOps.getLong(bytes, 0));
+        assertEquals(0x090A_0B0C_0D0E_0F10L, byteOps.getLong(bytes, 8));
+      }
+
+      @Test
+      void setFloatArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x00, 0x00, 0x00, 0x00,
+                  0x00, 0x00, 0x00, 0x00
+                });
+
+        byteOps.setFloatArray(
+            bytes,
+            0,
+            new float[] {Float.intBitsToFloat(0x3F80_0000), Float.intBitsToFloat(0x4000_0000)});
+
+        assertEquals(0x3F, byteOps.getByte(bytes, 0));
+        assertEquals((byte) 0x80, byteOps.getByte(bytes, 1));
+        assertEquals(0x00, byteOps.getByte(bytes, 2));
+        assertEquals(0x00, byteOps.getByte(bytes, 3));
+        assertEquals(0x40, byteOps.getByte(bytes, 4));
+        assertEquals(0x00, byteOps.getByte(bytes, 5));
+        assertEquals(0x00, byteOps.getByte(bytes, 6));
+        assertEquals(0x00, byteOps.getByte(bytes, 7));
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), byteOps.getFloat(bytes, 0));
+        assertEquals(Float.intBitsToFloat(0x4000_0000), byteOps.getFloat(bytes, 4));
+      }
+
+      @Test
+      void setDoubleArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+                });
+
+        byteOps.setDoubleArray(
+            bytes,
+            0,
+            new double[] {
+              Double.longBitsToDouble(0x3FF0_0000_0000_0000L),
+              Double.longBitsToDouble(0x4000_0000_0000_0000L)
+            });
+
+        assertEquals(0x3F, byteOps.getByte(bytes, 0));
+        assertEquals((byte) 0xF0, byteOps.getByte(bytes, 1));
+        assertEquals(0x00, byteOps.getByte(bytes, 2));
+        assertEquals(0x00, byteOps.getByte(bytes, 3));
+        assertEquals(0x00, byteOps.getByte(bytes, 4));
+        assertEquals(0x00, byteOps.getByte(bytes, 5));
+        assertEquals(0x00, byteOps.getByte(bytes, 6));
+        assertEquals(0x00, byteOps.getByte(bytes, 7));
+        assertEquals(0x40, byteOps.getByte(bytes, 8));
+        assertEquals(0x00, byteOps.getByte(bytes, 9));
+        assertEquals(0x00, byteOps.getByte(bytes, 10));
+        assertEquals(0x00, byteOps.getByte(bytes, 11));
+        assertEquals(0x00, byteOps.getByte(bytes, 12));
+        assertEquals(0x00, byteOps.getByte(bytes, 13));
+        assertEquals(0x00, byteOps.getByte(bytes, 14));
+        assertEquals(0x00, byteOps.getByte(bytes, 15));
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), byteOps.getDouble(bytes, 0));
+        assertEquals(Double.longBitsToDouble(0x4000_0000_0000_0000L), byteOps.getDouble(bytes, 8));
+      }
     }
-
-    @Test
-    void getShort() {
-      T bytes = getBytes(new byte[]{0x00, 0x01});
-
-      short s = byteOps.getShort(bytes, 0);
-
-      assertEquals(0x0001, s);
-    }
-
-    @Test
-    void setShort() {
-      T bytes = getBytes(new byte[]{0x00, 0x00});
-
-      byteOps.setShort(bytes, 0, (short) 0x0102);
-
-      assertEquals(0x01, byteOps.getByte(bytes, 0));
-      assertEquals(0x02, byteOps.getByte(bytes, 1));
-      assertEquals(0x0102, byteOps.getShort(bytes, 0));
-    }
-
-    @Test
-    void getInt() {
-      T bytes = getBytes(new byte[]{0x00, 0x01, 0x02, 0x03});
-
-      int i = byteOps.getInt(bytes, 0);
-
-      assertEquals(0x0001_0203, i);
-    }
-
-    @Test
-    void setInt() {
-      T bytes = getBytes(new byte[]{0x00, 0x00, 0x00, 0x00});
-
-      byteOps.setInt(bytes, 0, 0x0102_0304);
-
-      assertEquals(0x01, byteOps.getByte(bytes, 0));
-      assertEquals(0x02, byteOps.getByte(bytes, 1));
-      assertEquals(0x03, byteOps.getByte(bytes, 2));
-      assertEquals(0x04, byteOps.getByte(bytes, 3));
-      assertEquals(0x0102_0304, byteOps.getInt(bytes, 0));
-    }
-
-    @Test
-    void getLong() {
-      T bytes = getBytes(new byte[]{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
-
-      long l = byteOps.getLong(bytes, 0);
-
-      assertEquals(0x0001_0203_0405_0607L, l);
-    }
-
-    @Test
-    void setLong() {
-      T bytes = getBytes(new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-
-      byteOps.setLong(bytes, 0, 0x0102_0304_0506_0708L);
-
-      assertEquals(0x01, byteOps.getByte(bytes, 0));
-      assertEquals(0x02, byteOps.getByte(bytes, 1));
-      assertEquals(0x03, byteOps.getByte(bytes, 2));
-      assertEquals(0x04, byteOps.getByte(bytes, 3));
-      assertEquals(0x05, byteOps.getByte(bytes, 4));
-      assertEquals(0x06, byteOps.getByte(bytes, 5));
-      assertEquals(0x07, byteOps.getByte(bytes, 6));
-      assertEquals(0x08, byteOps.getByte(bytes, 7));
-      assertEquals(0x0102_0304_0506_0708L, byteOps.getLong(bytes, 0));
-    }
-
-    @Test
-    void getFloat() {
-      T bytes = getBytes(new byte[]{0x3F, (byte) 0x80, 0x00, 0x00});
-
-      float f = byteOps.getFloat(bytes, 0);
-
-      assertEquals(Float.intBitsToFloat(0x3F80_0000), f);
-    }
-
-    @Test
-    void setFloat() {
-      T bytes = getBytes(new byte[]{0x00, 0x00, 0x00, 0x00});
-
-      byteOps.setFloat(bytes, 0, Float.intBitsToFloat(0x3F80_0000));
-
-      assertEquals(0x3F, byteOps.getByte(bytes, 0));
-      assertEquals((byte) 0x80, byteOps.getByte(bytes, 1));
-      assertEquals(0x00, byteOps.getByte(bytes, 2));
-      assertEquals(0x00, byteOps.getByte(bytes, 3));
-      assertEquals(Float.intBitsToFloat(0x3F80_0000), byteOps.getFloat(bytes, 0));
-    }
-
-    @Test
-    void getDouble() {
-      T bytes = getBytes(new byte[]{0x3F, (byte) 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-
-      double d = byteOps.getDouble(bytes, 0);
-
-      assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), d);
-    }
-
-    @Test
-    void setDouble() {
-      T bytes = getBytes(new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-
-      byteOps.setDouble(bytes, 0, Double.longBitsToDouble(0x3FF0_0000_0000_0000L));
-
-      assertEquals(0x3F, byteOps.getByte(bytes, 0));
-      assertEquals((byte) 0xF0, byteOps.getByte(bytes, 1));
-      assertEquals(0x00, byteOps.getByte(bytes, 2));
-      assertEquals(0x00, byteOps.getByte(bytes, 3));
-      assertEquals(0x00, byteOps.getByte(bytes, 4));
-      assertEquals(0x00, byteOps.getByte(bytes, 5));
-      assertEquals(0x00, byteOps.getByte(bytes, 6));
-      assertEquals(0x00, byteOps.getByte(bytes, 7));
-      assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), byteOps.getDouble(bytes, 0));
-    }
-
   }
 
   @Nested
@@ -177,102 +437,293 @@ abstract class AbstractByteOpsTest<T> {
 
     private final ByteOps<T> byteOps = getSwappedByteOps(ByteOrder.BIG_ENDIAN);
 
-    @Test
-    void getInt() {
-      T bytes = getBytes(new byte[]{0x00, 0x01, 0x02, 0x03});
+    @Nested
+    class ScalarGet {
 
-      int i = byteOps.getInt(bytes, 0);
+      @Test
+      void getInt() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03});
 
-      assertEquals(0x0203_0001, i);
+        int i = byteOps.getInt(bytes, 0);
+
+        assertEquals(0x0203_0001, i);
+      }
+
+      @Test
+      void getLong() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
+
+        long l = byteOps.getLong(bytes, 0);
+
+        assertEquals(0x0607_0405_0203_0001L, l);
+      }
+
+      @Test
+      void getFloat() {
+        T bytes = getBytes(new byte[] {0x3F, (byte) 0x80, 0x00, 0x00});
+
+        float f = byteOps.getFloat(bytes, 0);
+
+        assertEquals(Float.intBitsToFloat(0x0000_3F80), f);
+      }
+
+      @Test
+      void getDouble() {
+        T bytes = getBytes(new byte[] {0x3F, (byte) 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+
+        double d = byteOps.getDouble(bytes, 0);
+
+        assertEquals(Double.longBitsToDouble(0x0000_0000_0000_3FF0L), d);
+      }
     }
 
-    @Test
-    void setInt() {
-      T bytes = getBytes(new byte[4]);
+    @Nested
+    class ScalarSet {
 
-      byteOps.setInt(bytes, 0, 0x0102_0304);
+      @Test
+      void setInt() {
+        T bytes = getBytes(new byte[4]);
 
-      assertEquals(0x03, byteOps.getByte(bytes, 0));
-      assertEquals(0x04, byteOps.getByte(bytes, 1));
-      assertEquals(0x01, byteOps.getByte(bytes, 2));
-      assertEquals(0x02, byteOps.getByte(bytes, 3));
-      assertEquals(0x0102_0304, byteOps.getInt(bytes, 0));
+        byteOps.setInt(bytes, 0, 0x0102_0304);
+
+        assertEquals(0x03, byteOps.getByte(bytes, 0));
+        assertEquals(0x04, byteOps.getByte(bytes, 1));
+        assertEquals(0x01, byteOps.getByte(bytes, 2));
+        assertEquals(0x02, byteOps.getByte(bytes, 3));
+        assertEquals(0x0102_0304, byteOps.getInt(bytes, 0));
+      }
+
+      @Test
+      void setLong() {
+        T bytes = getBytes(new byte[8]);
+
+        byteOps.setLong(bytes, 0, 0x0102_0304_0506_0708L);
+
+        assertEquals(0x07, byteOps.getByte(bytes, 0));
+        assertEquals(0x08, byteOps.getByte(bytes, 1));
+        assertEquals(0x05, byteOps.getByte(bytes, 2));
+        assertEquals(0x06, byteOps.getByte(bytes, 3));
+        assertEquals(0x03, byteOps.getByte(bytes, 4));
+        assertEquals(0x04, byteOps.getByte(bytes, 5));
+        assertEquals(0x01, byteOps.getByte(bytes, 6));
+        assertEquals(0x02, byteOps.getByte(bytes, 7));
+        assertEquals(0x0102_0304_0506_0708L, byteOps.getLong(bytes, 0));
+      }
+
+      @Test
+      void setFloat() {
+        T bytes = getBytes(new byte[4]);
+
+        byteOps.setFloat(bytes, 0, Float.intBitsToFloat(0x3F80_0000));
+
+        assertEquals(0x00, byteOps.getByte(bytes, 0));
+        assertEquals(0x00, byteOps.getByte(bytes, 1));
+        assertEquals(0x3F, byteOps.getByte(bytes, 2));
+        assertEquals((byte) 0x80, byteOps.getByte(bytes, 3));
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), byteOps.getFloat(bytes, 0));
+      }
+
+      @Test
+      void setDouble() {
+        T bytes = getBytes(new byte[8]);
+
+        byteOps.setDouble(bytes, 0, Double.longBitsToDouble(0x3FF0_0000_0000_0000L));
+
+        assertEquals(0x00, byteOps.getByte(bytes, 0));
+        assertEquals(0x00, byteOps.getByte(bytes, 1));
+        assertEquals(0x00, byteOps.getByte(bytes, 2));
+        assertEquals(0x00, byteOps.getByte(bytes, 3));
+        assertEquals(0x00, byteOps.getByte(bytes, 4));
+        assertEquals(0x00, byteOps.getByte(bytes, 5));
+        assertEquals(0x3F, byteOps.getByte(bytes, 6));
+        assertEquals((byte) 0xF0, byteOps.getByte(bytes, 7));
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), byteOps.getDouble(bytes, 0));
+      }
     }
 
-    @Test
-    void getLong() {
-      T bytes = getBytes(new byte[]{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
+    @Nested
+    class ArrayGet {
 
-      long l = byteOps.getLong(bytes, 0);
+      @Test
+      void getIntArray() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
 
-      assertEquals(0x0607_0405_0203_0001L, l);
+        int[] is = byteOps.getIntArray(bytes, 0, 2);
+
+        assertEquals(0x0203_0001, is[0]);
+        assertEquals(0x0607_0405, is[1]);
+        assertArrayEquals(new int[] {0x0203_0001, 0x0607_0405}, is);
+      }
+
+      @Test
+      void getLongArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                  0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
+                });
+
+        long[] ls = byteOps.getLongArray(bytes, 0, 2);
+
+        assertEquals(0x0607_0405_0203_0001L, ls[0]);
+        assertEquals(0x0E0F_0C0D_0A0B_0809L, ls[1]);
+        assertArrayEquals(new long[] {0x0607_0405_0203_0001L, 0x0E0F_0C0D_0A0B_0809L}, ls);
+      }
+
+      @Test
+      void getFloatArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x3F, (byte) 0x80, 0x00, 0x00,
+                  0x3F, (byte) 0x80, 0x00, 0x00
+                });
+
+        float[] fs = byteOps.getFloatArray(bytes, 0, 2);
+
+        assertEquals(Float.intBitsToFloat(0x0000_3F80), fs[0]);
+        assertEquals(Float.intBitsToFloat(0x0000_3F80), fs[1]);
+        assertArrayEquals(
+            new float[] {Float.intBitsToFloat(0x0000_3F80), Float.intBitsToFloat(0x0000_3F80)}, fs);
+      }
+
+      @Test
+      void getDoubleArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x3F,
+                  (byte) 0xF0,
+                  0x00,
+                  0x00,
+                  0x00,
+                  0x00,
+                  0x00,
+                  0x00,
+                  0x40,
+                  0x00,
+                  0x00,
+                  0x00,
+                  0x00,
+                  0x00,
+                  0x00,
+                  0x00
+                });
+
+        double[] ds = byteOps.getDoubleArray(bytes, 0, 2);
+
+        assertEquals(Double.longBitsToDouble(0x0000_0000_0000_3FF0L), ds[0]);
+        assertEquals(Double.longBitsToDouble(0x0000_0000_0000_4000L), ds[1]);
+        assertArrayEquals(
+            new double[] {
+              Double.longBitsToDouble(0x0000_0000_0000_3FF0L),
+              Double.longBitsToDouble(0x0000_0000_0000_4000L)
+            },
+            ds);
+      }
     }
 
-    @Test
-    void setLong() {
-      T bytes = getBytes(new byte[8]);
+    @Nested
+    class ArraySet {
 
-      byteOps.setLong(bytes, 0, 0x0102_0304_0506_0708L);
+      @Test
+      void setIntArray() {
+        T bytes = getBytes(new byte[8]);
 
-      assertEquals(0x07, byteOps.getByte(bytes, 0));
-      assertEquals(0x08, byteOps.getByte(bytes, 1));
-      assertEquals(0x05, byteOps.getByte(bytes, 2));
-      assertEquals(0x06, byteOps.getByte(bytes, 3));
-      assertEquals(0x03, byteOps.getByte(bytes, 4));
-      assertEquals(0x04, byteOps.getByte(bytes, 5));
-      assertEquals(0x01, byteOps.getByte(bytes, 6));
-      assertEquals(0x02, byteOps.getByte(bytes, 7));
-      assertEquals(0x0102_0304_0506_0708L, byteOps.getLong(bytes, 0));
+        byteOps.setIntArray(bytes, 0, new int[] {0x0102_0304, 0x0506_0708});
+
+        assertEquals(0x03, byteOps.getByte(bytes, 0));
+        assertEquals(0x04, byteOps.getByte(bytes, 1));
+        assertEquals(0x01, byteOps.getByte(bytes, 2));
+        assertEquals(0x02, byteOps.getByte(bytes, 3));
+        assertEquals(0x07, byteOps.getByte(bytes, 4));
+        assertEquals(0x08, byteOps.getByte(bytes, 5));
+        assertEquals(0x05, byteOps.getByte(bytes, 6));
+        assertEquals(0x06, byteOps.getByte(bytes, 7));
+        assertEquals(0x0102_0304, byteOps.getInt(bytes, 0));
+        assertEquals(0x0506_0708, byteOps.getInt(bytes, 4));
+      }
+
+      @Test
+      void setLongArray() {
+        T bytes = getBytes(new byte[16]);
+
+        byteOps.setLongArray(bytes, 0, new long[] {0x0102_0304_0506_0708L, 0x090A_0B0C_0D0E_0F10L});
+
+        assertEquals(0x07, byteOps.getByte(bytes, 0));
+        assertEquals(0x08, byteOps.getByte(bytes, 1));
+        assertEquals(0x05, byteOps.getByte(bytes, 2));
+        assertEquals(0x06, byteOps.getByte(bytes, 3));
+        assertEquals(0x03, byteOps.getByte(bytes, 4));
+        assertEquals(0x04, byteOps.getByte(bytes, 5));
+        assertEquals(0x01, byteOps.getByte(bytes, 6));
+        assertEquals(0x02, byteOps.getByte(bytes, 7));
+        assertEquals(0x0F, byteOps.getByte(bytes, 8));
+        assertEquals(0x10, byteOps.getByte(bytes, 9));
+        assertEquals(0x0D, byteOps.getByte(bytes, 10));
+        assertEquals(0x0E, byteOps.getByte(bytes, 11));
+        assertEquals(0x0B, byteOps.getByte(bytes, 12));
+        assertEquals(0x0C, byteOps.getByte(bytes, 13));
+        assertEquals(0x09, byteOps.getByte(bytes, 14));
+        assertEquals(0x0A, byteOps.getByte(bytes, 15));
+        assertEquals(0x0102_0304_0506_0708L, byteOps.getLong(bytes, 0));
+        assertEquals(0x090A_0B0C_0D0E_0F10L, byteOps.getLong(bytes, 8));
+      }
+
+      @Test
+      void setFloatArray() {
+        T bytes = getBytes(new byte[8]);
+
+        byteOps.setFloatArray(
+            bytes,
+            0,
+            new float[] {Float.intBitsToFloat(0x3F80_0000), Float.intBitsToFloat(0x4000_0000)});
+
+        assertEquals(0x00, byteOps.getByte(bytes, 0));
+        assertEquals(0x00, byteOps.getByte(bytes, 1));
+        assertEquals(0x3F, byteOps.getByte(bytes, 2));
+        assertEquals((byte) 0x80, byteOps.getByte(bytes, 3));
+        assertEquals(0x00, byteOps.getByte(bytes, 4));
+        assertEquals(0x00, byteOps.getByte(bytes, 5));
+        assertEquals(0x40, byteOps.getByte(bytes, 6));
+        assertEquals(0x00, byteOps.getByte(bytes, 7));
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), byteOps.getFloat(bytes, 0));
+        assertEquals(Float.intBitsToFloat(0x4000_0000), byteOps.getFloat(bytes, 4));
+      }
+
+      @Test
+      void setDoubleArray() {
+        T bytes = getBytes(new byte[16]);
+
+        byteOps.setDoubleArray(
+            bytes,
+            0,
+            new double[] {
+              Double.longBitsToDouble(0x3FF0_0000_0000_0000L),
+              Double.longBitsToDouble(0x4000_0000_0000_0000L)
+            });
+
+        assertEquals(0x00, byteOps.getByte(bytes, 0));
+        assertEquals(0x00, byteOps.getByte(bytes, 1));
+        assertEquals(0x00, byteOps.getByte(bytes, 2));
+        assertEquals(0x00, byteOps.getByte(bytes, 3));
+        assertEquals(0x00, byteOps.getByte(bytes, 4));
+        assertEquals(0x00, byteOps.getByte(bytes, 5));
+        assertEquals(0x3F, byteOps.getByte(bytes, 6));
+        assertEquals((byte) 0xF0, byteOps.getByte(bytes, 7));
+        assertEquals(0x00, byteOps.getByte(bytes, 8));
+        assertEquals(0x00, byteOps.getByte(bytes, 9));
+        assertEquals(0x00, byteOps.getByte(bytes, 10));
+        assertEquals(0x00, byteOps.getByte(bytes, 11));
+        assertEquals(0x00, byteOps.getByte(bytes, 12));
+        assertEquals(0x00, byteOps.getByte(bytes, 13));
+        assertEquals(0x40, byteOps.getByte(bytes, 14));
+        assertEquals(0x00, byteOps.getByte(bytes, 15));
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), byteOps.getDouble(bytes, 0));
+        assertEquals(Double.longBitsToDouble(0x4000_0000_0000_0000L), byteOps.getDouble(bytes, 8));
+      }
     }
-
-    @Test
-    void getFloat() {
-      T bytes = getBytes(new byte[]{0x3F, (byte) 0x80, 0x00, 0x00});
-
-      float f = byteOps.getFloat(bytes, 0);
-
-      assertEquals(Float.intBitsToFloat(0x0000_3F80), f);
-    }
-
-    @Test
-    void setFloat() {
-      T bytes = getBytes(new byte[4]);
-
-      byteOps.setFloat(bytes, 0, Float.intBitsToFloat(0x3F80_0000));
-
-      assertEquals(0x00, byteOps.getByte(bytes, 0));
-      assertEquals(0x00, byteOps.getByte(bytes, 1));
-      assertEquals(0x3F, byteOps.getByte(bytes, 2));
-      assertEquals((byte) 0x80, byteOps.getByte(bytes, 3));
-      assertEquals(Float.intBitsToFloat(0x3F80_0000), byteOps.getFloat(bytes, 0));
-    }
-
-    @Test
-    void getDouble() {
-      T bytes = getBytes(new byte[]{0x3F, (byte) 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-
-      double d = byteOps.getDouble(bytes, 0);
-
-      assertEquals(Double.longBitsToDouble(0x0000_0000_0000_3FF0L), d);
-    }
-
-    @Test
-    void setDouble() {
-      T bytes = getBytes(new byte[8]);
-
-      byteOps.setDouble(bytes, 0, Double.longBitsToDouble(0x3FF0_0000_0000_0000L));
-
-      assertEquals(0x00, byteOps.getByte(bytes, 0));
-      assertEquals(0x00, byteOps.getByte(bytes, 1));
-      assertEquals(0x00, byteOps.getByte(bytes, 2));
-      assertEquals(0x00, byteOps.getByte(bytes, 3));
-      assertEquals(0x00, byteOps.getByte(bytes, 4));
-      assertEquals(0x00, byteOps.getByte(bytes, 5));
-      assertEquals(0x3F, byteOps.getByte(bytes, 6));
-      assertEquals((byte) 0xF0, byteOps.getByte(bytes, 7));
-      assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), byteOps.getDouble(bytes, 0));
-    }
-
   }
 
   @Nested
@@ -280,155 +731,371 @@ abstract class AbstractByteOpsTest<T> {
 
     private final ByteOps<T> byteOps = getByteOps(ByteOrder.LITTLE_ENDIAN);
 
-    @Test
-    void getBoolean() {
-      assertFalse(byteOps.getBoolean(getBytes(new byte[]{0x00}), 0));
-      assertTrue(byteOps.getBoolean(getBytes(new byte[]{0x01}), 0));
+    @Nested
+    class ScalarGet {
+
+      @Test
+      void getBoolean() {
+        assertFalse(byteOps.getBoolean(getBytes(new byte[] {0x00}), 0));
+        assertTrue(byteOps.getBoolean(getBytes(new byte[] {0x01}), 0));
+      }
+
+      @Test
+      void getByte() {
+        T bytes = getBytes(new byte[] {0x00});
+
+        byte b = byteOps.getByte(bytes, 0);
+
+        assertEquals(0x00, b);
+      }
+
+      @Test
+      void getShort() {
+        T bytes = getBytes(new byte[] {0x00, 0x01});
+
+        short s = byteOps.getShort(bytes, 0);
+
+        assertEquals(0x0100, s);
+      }
+
+      @Test
+      void getInt() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03});
+
+        int i = byteOps.getInt(bytes, 0);
+
+        assertEquals(0x0302_0100, i);
+      }
+
+      @Test
+      void getLong() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
+
+        long l = byteOps.getLong(bytes, 0);
+
+        assertEquals(0x0706_0504_0302_0100L, l);
+      }
+
+      @Test
+      void getFloat() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, (byte) 0x80, 0x3F});
+
+        float f = byteOps.getFloat(bytes, 0);
+
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), f);
+      }
+
+      @Test
+      void getDouble() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xF0, 0x3F});
+
+        double d = byteOps.getDouble(bytes, 0);
+
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), d);
+      }
     }
 
-    @Test
-    void setBoolean() {
-      T bytes = getBytes(new byte[]{0x00});
+    @Nested
+    class ScalarSet {
 
-      byteOps.setBoolean(bytes, 0, true);
+      @Test
+      void setBoolean() {
+        T bytes = getBytes(new byte[] {0x00});
 
-      assertTrue(byteOps.getBoolean(bytes, 0));
-    }
-    
-    @Test
-    void getByte() {
-      T bytes = getBytes(new byte[]{0x00});
+        byteOps.setBoolean(bytes, 0, true);
 
-      byte b = byteOps.getByte(bytes, 0);
+        assertTrue(byteOps.getBoolean(bytes, 0));
+      }
 
-      assertEquals(0x00, b);
-    }
+      @Test
+      void setByte() {
+        T bytes = getBytes(new byte[] {0x00});
 
-    @Test
-    void setByte() {
-      T bytes = getBytes(new byte[]{0x00});
+        byteOps.setByte(bytes, 0, (byte) 0x01);
 
-      byteOps.setByte(bytes, 0, (byte) 0x01);
+        assertEquals(0x01, byteOps.getByte(bytes, 0));
+      }
 
-      assertEquals(0x01, byteOps.getByte(bytes, 0));
-    }
+      @Test
+      void setShort() {
+        T bytes = getBytes(new byte[] {0x00, 0x00});
 
-    @Test
-    void getShort() {
-      T bytes = getBytes(new byte[]{0x00, 0x01});
+        byteOps.setShort(bytes, 0, (short) 0x0102);
 
-      short s = byteOps.getShort(bytes, 0);
+        assertEquals(0x02, byteOps.getByte(bytes, 0));
+        assertEquals(0x01, byteOps.getByte(bytes, 1));
+        assertEquals(0x0102, byteOps.getShort(bytes, 0));
+      }
 
-      assertEquals(0x0100, s);
-    }
+      @Test
+      void setInt() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, 0x00, 0x00});
 
-    @Test
-    void setShort() {
-      T bytes = getBytes(new byte[]{0x00, 0x00});
+        byteOps.setInt(bytes, 0, 0x0102_0304);
 
-      byteOps.setShort(bytes, 0, (short) 0x0102);
+        assertEquals(0x04, byteOps.getByte(bytes, 0));
+        assertEquals(0x03, byteOps.getByte(bytes, 1));
+        assertEquals(0x02, byteOps.getByte(bytes, 2));
+        assertEquals(0x01, byteOps.getByte(bytes, 3));
+        assertEquals(0x0102_0304, byteOps.getInt(bytes, 0));
+      }
 
-      assertEquals(0x02, byteOps.getByte(bytes, 0));
-      assertEquals(0x01, byteOps.getByte(bytes, 1));
-      assertEquals(0x0102, byteOps.getShort(bytes, 0));
-    }
+      @Test
+      void setLong() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
 
-    @Test
-    void getInt() {
-      T bytes = getBytes(new byte[]{0x00, 0x01, 0x02, 0x03});
+        byteOps.setLong(bytes, 0, 0x0102_0304_0506_0708L);
 
-      int i = byteOps.getInt(bytes, 0);
+        assertEquals(0x08, byteOps.getByte(bytes, 0));
+        assertEquals(0x07, byteOps.getByte(bytes, 1));
+        assertEquals(0x06, byteOps.getByte(bytes, 2));
+        assertEquals(0x05, byteOps.getByte(bytes, 3));
+        assertEquals(0x04, byteOps.getByte(bytes, 4));
+        assertEquals(0x03, byteOps.getByte(bytes, 5));
+        assertEquals(0x02, byteOps.getByte(bytes, 6));
+        assertEquals(0x01, byteOps.getByte(bytes, 7));
+        assertEquals(0x0102_0304_0506_0708L, byteOps.getLong(bytes, 0));
+      }
 
-      assertEquals(0x0302_0100, i);
-    }
+      @Test
+      void setFloat() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, 0x00, 0x00});
 
-    @Test
-    void setInt() {
-      T bytes = getBytes(new byte[]{0x00, 0x00, 0x00, 0x00});
+        byteOps.setFloat(bytes, 0, Float.intBitsToFloat(0x3F80_0000));
 
-      byteOps.setInt(bytes, 0, 0x0102_0304);
+        assertEquals(0x00, byteOps.getByte(bytes, 0));
+        assertEquals(0x00, byteOps.getByte(bytes, 1));
+        assertEquals((byte) 0x80, byteOps.getByte(bytes, 2));
+        assertEquals(0x3F, byteOps.getByte(bytes, 3));
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), byteOps.getFloat(bytes, 0));
+      }
 
-      assertEquals(0x04, byteOps.getByte(bytes, 0));
-      assertEquals(0x03, byteOps.getByte(bytes, 1));
-      assertEquals(0x02, byteOps.getByte(bytes, 2));
-      assertEquals(0x01, byteOps.getByte(bytes, 3));
-      assertEquals(0x0102_0304, byteOps.getInt(bytes, 0));
-    }
+      @Test
+      void setDouble() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
 
-    @Test
-    void getLong() {
-      T bytes = getBytes(new byte[]{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
+        byteOps.setDouble(bytes, 0, Double.longBitsToDouble(0x3FF0_0000_0000_0000L));
 
-      long l = byteOps.getLong(bytes, 0);
-
-      assertEquals(0x0706_0504_0302_0100L, l);
-    }
-
-    @Test
-    void setLong() {
-      T bytes = getBytes(new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-
-      byteOps.setLong(bytes, 0, 0x0102_0304_0506_0708L);
-
-      assertEquals(0x08, byteOps.getByte(bytes, 0));
-      assertEquals(0x07, byteOps.getByte(bytes, 1));
-      assertEquals(0x06, byteOps.getByte(bytes, 2));
-      assertEquals(0x05, byteOps.getByte(bytes, 3));
-      assertEquals(0x04, byteOps.getByte(bytes, 4));
-      assertEquals(0x03, byteOps.getByte(bytes, 5));
-      assertEquals(0x02, byteOps.getByte(bytes, 6));
-      assertEquals(0x01, byteOps.getByte(bytes, 7));
-      assertEquals(0x0102_0304_0506_0708L, byteOps.getLong(bytes, 0));
+        assertEquals(0x00, byteOps.getByte(bytes, 0));
+        assertEquals(0x00, byteOps.getByte(bytes, 1));
+        assertEquals(0x00, byteOps.getByte(bytes, 2));
+        assertEquals(0x00, byteOps.getByte(bytes, 3));
+        assertEquals(0x00, byteOps.getByte(bytes, 4));
+        assertEquals(0x00, byteOps.getByte(bytes, 5));
+        assertEquals((byte) 0xF0, byteOps.getByte(bytes, 6));
+        assertEquals(0x3F, byteOps.getByte(bytes, 7));
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), byteOps.getDouble(bytes, 0));
+      }
     }
 
-    @Test
-    void getFloat() {
-      T bytes = getBytes(new byte[]{0x00, 0x00, (byte) 0x80, 0x3F});
+    @Nested
+    class ArrayGet {
 
-      float f = byteOps.getFloat(bytes, 0);
+      @Test
+      void getShortArray() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03});
 
-      assertEquals(Float.intBitsToFloat(0x3F80_0000), f);
+        short[] shorts = byteOps.getShortArray(bytes, 0, 2);
+
+        assertEquals(0x0100, shorts[0]);
+        assertEquals(0x0302, shorts[1]);
+        assertArrayEquals(new short[] {0x0100, 0x0302}, shorts);
+      }
+
+      @Test
+      void getIntArray() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
+
+        int[] is = byteOps.getIntArray(bytes, 0, 2);
+
+        assertEquals(0x0302_0100, is[0]);
+        assertEquals(0x0706_0504, is[1]);
+        assertArrayEquals(new int[] {0x0302_0100, 0x0706_0504}, is);
+      }
+
+      @Test
+      void getLongArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                  0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
+                });
+
+        long[] ls = byteOps.getLongArray(bytes, 0, 2);
+
+        assertEquals(0x0706_0504_0302_0100L, ls[0]);
+        assertEquals(0x0F0E_0D0C_0B0A_0908L, ls[1]);
+        assertArrayEquals(new long[] {0x0706_0504_0302_0100L, 0x0F0E_0D0C_0B0A_0908L}, ls);
+      }
+
+      @Test
+      void getFloatArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x00, 0x00, (byte) 0x80, 0x3F,
+                  0x00, 0x00, (byte) 0x80, 0x3F
+                });
+
+        float[] fs = byteOps.getFloatArray(bytes, 0, 2);
+
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), fs[0]);
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), fs[1]);
+        assertArrayEquals(
+            new float[] {Float.intBitsToFloat(0x3F80_0000), Float.intBitsToFloat(0x3F80_0000)}, fs);
+      }
+
+      @Test
+      void getDoubleArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xF0, 0x3F,
+                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xF0, 0x3F
+                });
+
+        double[] ds = byteOps.getDoubleArray(bytes, 0, 2);
+
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), ds[0]);
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), ds[1]);
+        assertArrayEquals(
+            new double[] {
+              Double.longBitsToDouble(0x3FF0_0000_0000_0000L),
+              Double.longBitsToDouble(0x3FF0_0000_0000_0000L)
+            },
+            ds);
+      }
     }
 
-    @Test
-    void setFloat() {
-      T bytes = getBytes(new byte[]{0x00, 0x00, 0x00, 0x00});
+    @Nested
+    class ArraySet {
 
-      byteOps.setFloat(bytes, 0, Float.intBitsToFloat(0x3F80_0000));
+      @Test
+      void setShortArray() {
+        T bytes = getBytes(new byte[4]);
 
-      assertEquals(0x00, byteOps.getByte(bytes, 0));
-      assertEquals(0x00, byteOps.getByte(bytes, 1));
-      assertEquals((byte) 0x80, byteOps.getByte(bytes, 2));
-      assertEquals(0x3F, byteOps.getByte(bytes, 3));
-      assertEquals(Float.intBitsToFloat(0x3F80_0000), byteOps.getFloat(bytes, 0));
+        byteOps.setShortArray(bytes, 0, new short[] {0x0102, 0x0304});
+
+        assertEquals(0x02, byteOps.getByte(bytes, 0));
+        assertEquals(0x01, byteOps.getByte(bytes, 1));
+        assertEquals(0x04, byteOps.getByte(bytes, 2));
+        assertEquals(0x03, byteOps.getByte(bytes, 3));
+        assertEquals(0x0102, byteOps.getShort(bytes, 0));
+        assertEquals(0x0304, byteOps.getShort(bytes, 2));
+        assertArrayEquals(new short[] {0x0102, 0x0304}, byteOps.getShortArray(bytes, 0, 2));
+      }
+
+      @Test
+      void setIntArray() {
+        T bytes = getBytes(new byte[8]);
+
+        byteOps.setIntArray(bytes, 0, new int[] {0x0102_0304, 0x0506_0708});
+
+        assertEquals(0x04, byteOps.getByte(bytes, 0));
+        assertEquals(0x03, byteOps.getByte(bytes, 1));
+        assertEquals(0x02, byteOps.getByte(bytes, 2));
+        assertEquals(0x01, byteOps.getByte(bytes, 3));
+        assertEquals(0x08, byteOps.getByte(bytes, 4));
+        assertEquals(0x07, byteOps.getByte(bytes, 5));
+        assertEquals(0x06, byteOps.getByte(bytes, 6));
+        assertEquals(0x05, byteOps.getByte(bytes, 7));
+        assertEquals(0x0102_0304, byteOps.getInt(bytes, 0));
+        assertEquals(0x0506_0708, byteOps.getInt(bytes, 4));
+        assertArrayEquals(new int[] {0x0102_0304, 0x0506_0708}, byteOps.getIntArray(bytes, 0, 2));
+      }
+
+      @Test
+      void setLongArray() {
+        T bytes = getBytes(new byte[16]);
+
+        byteOps.setLongArray(bytes, 0, new long[] {0x0102_0304_0506_0708L, 0x090A_0B0C_0D0E_0F10L});
+
+        assertEquals(0x08, byteOps.getByte(bytes, 0));
+        assertEquals(0x07, byteOps.getByte(bytes, 1));
+        assertEquals(0x06, byteOps.getByte(bytes, 2));
+        assertEquals(0x05, byteOps.getByte(bytes, 3));
+        assertEquals(0x04, byteOps.getByte(bytes, 4));
+        assertEquals(0x03, byteOps.getByte(bytes, 5));
+        assertEquals(0x02, byteOps.getByte(bytes, 6));
+        assertEquals(0x01, byteOps.getByte(bytes, 7));
+        assertEquals(0x10, byteOps.getByte(bytes, 8));
+        assertEquals(0x0F, byteOps.getByte(bytes, 9));
+        assertEquals(0x0E, byteOps.getByte(bytes, 10));
+        assertEquals(0x0D, byteOps.getByte(bytes, 11));
+        assertEquals(0x0C, byteOps.getByte(bytes, 12));
+        assertEquals(0x0B, byteOps.getByte(bytes, 13));
+        assertEquals(0x0A, byteOps.getByte(bytes, 14));
+        assertEquals(0x09, byteOps.getByte(bytes, 15));
+        assertEquals(0x0102_0304_0506_0708L, byteOps.getLong(bytes, 0));
+        assertEquals(0x090A_0B0C_0D0E_0F10L, byteOps.getLong(bytes, 8));
+        assertArrayEquals(
+            new long[] {0x0102_0304_0506_0708L, 0x090A_0B0C_0D0E_0F10L},
+            byteOps.getLongArray(bytes, 0, 2));
+      }
+
+      @Test
+      void setFloatArray() {
+        T bytes = getBytes(new byte[8]);
+
+        byteOps.setFloatArray(
+            bytes,
+            0,
+            new float[] {Float.intBitsToFloat(0x3F80_0000), Float.intBitsToFloat(0x4000_0000)});
+
+        assertEquals(0x00, byteOps.getByte(bytes, 0));
+        assertEquals(0x00, byteOps.getByte(bytes, 1));
+        assertEquals((byte) 0x80, byteOps.getByte(bytes, 2));
+        assertEquals(0x3F, byteOps.getByte(bytes, 3));
+        assertEquals(0x00, byteOps.getByte(bytes, 4));
+        assertEquals(0x00, byteOps.getByte(bytes, 5));
+        assertEquals(0x00, byteOps.getByte(bytes, 6));
+        assertEquals(0x40, byteOps.getByte(bytes, 7));
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), byteOps.getFloat(bytes, 0));
+        assertEquals(Float.intBitsToFloat(0x4000_0000), byteOps.getFloat(bytes, 4));
+        assertArrayEquals(
+            new float[] {Float.intBitsToFloat(0x3F80_0000), Float.intBitsToFloat(0x4000_0000)},
+            byteOps.getFloatArray(bytes, 0, 2));
+      }
+
+      @Test
+      void setDoubleArray() {
+        T bytes = getBytes(new byte[16]);
+
+        byteOps.setDoubleArray(
+            bytes,
+            0,
+            new double[] {
+              Double.longBitsToDouble(0x3FF0_0000_0000_0000L),
+              Double.longBitsToDouble(0x4000_0000_0000_0000L)
+            });
+
+        assertEquals(0x00, byteOps.getByte(bytes, 0));
+        assertEquals(0x00, byteOps.getByte(bytes, 1));
+        assertEquals(0x00, byteOps.getByte(bytes, 2));
+        assertEquals(0x00, byteOps.getByte(bytes, 3));
+        assertEquals(0x00, byteOps.getByte(bytes, 4));
+        assertEquals(0x00, byteOps.getByte(bytes, 5));
+        assertEquals((byte) 0xF0, byteOps.getByte(bytes, 6));
+        assertEquals(0x3F, byteOps.getByte(bytes, 7));
+        assertEquals(0x00, byteOps.getByte(bytes, 8));
+        assertEquals(0x00, byteOps.getByte(bytes, 9));
+        assertEquals(0x00, byteOps.getByte(bytes, 10));
+        assertEquals(0x00, byteOps.getByte(bytes, 11));
+        assertEquals(0x00, byteOps.getByte(bytes, 12));
+        assertEquals(0x00, byteOps.getByte(bytes, 13));
+        assertEquals(0x00, byteOps.getByte(bytes, 14));
+        assertEquals(0x40, byteOps.getByte(bytes, 15));
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), byteOps.getDouble(bytes, 0));
+        assertEquals(Double.longBitsToDouble(0x4000_0000_0000_0000L), byteOps.getDouble(bytes, 8));
+        assertArrayEquals(
+            new double[] {
+              Double.longBitsToDouble(0x3FF0_0000_0000_0000L),
+              Double.longBitsToDouble(0x4000_0000_0000_0000L)
+            },
+            byteOps.getDoubleArray(bytes, 0, 2));
+      }
     }
-
-    @Test
-    void getDouble() {
-      T bytes = getBytes(new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xF0, 0x3F});
-
-      double d = byteOps.getDouble(bytes, 0);
-
-      assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), d);
-    }
-
-    @Test
-    void setDouble() {
-      T bytes = getBytes(new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-
-      byteOps.setDouble(bytes, 0, Double.longBitsToDouble(0x3FF0_0000_0000_0000L));
-
-      assertEquals(0x00, byteOps.getByte(bytes, 0));
-      assertEquals(0x00, byteOps.getByte(bytes, 1));
-      assertEquals(0x00, byteOps.getByte(bytes, 2));
-      assertEquals(0x00, byteOps.getByte(bytes, 3));
-      assertEquals(0x00, byteOps.getByte(bytes, 4));
-      assertEquals(0x00, byteOps.getByte(bytes, 5));
-      assertEquals((byte) 0xF0, byteOps.getByte(bytes, 6));
-      assertEquals(0x3F, byteOps.getByte(bytes, 7));
-      assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), byteOps.getDouble(bytes, 0));
-    }
-
   }
 
   @Nested
@@ -436,102 +1103,290 @@ abstract class AbstractByteOpsTest<T> {
 
     private final ByteOps<T> byteOps = getSwappedByteOps(ByteOrder.LITTLE_ENDIAN);
 
-    @Test
-    void getInt() {
-      T bytes = getBytes(new byte[]{0x00, 0x01, 0x02, 0x03});
+    @Nested
+    class ScalarGet {
 
-      int i = byteOps.getInt(bytes, 0);
+      @Test
+      void getInt() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03});
 
-      assertEquals(0x0100_0302, i);
+        int i = byteOps.getInt(bytes, 0);
+
+        assertEquals(0x0100_0302, i);
+      }
+
+      @Test
+      void getLong() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
+
+        long l = byteOps.getLong(bytes, 0);
+
+        assertEquals(0x0100_0302_0504_0706L, l);
+      }
+
+      @Test
+      void getFloat() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, (byte) 0x80, 0x3F});
+
+        float f = byteOps.getFloat(bytes, 0);
+
+        assertEquals(Float.intBitsToFloat(0x0000_3F80), f);
+      }
+
+      @Test
+      void getDouble() {
+        T bytes = getBytes(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xF0, 0x3F});
+
+        double d = byteOps.getDouble(bytes, 0);
+
+        assertEquals(Double.longBitsToDouble(0x0000_0000_0000_3FF0L), d);
+      }
     }
 
-    @Test
-    void setInt() {
-      T bytes = getBytes(new byte[4]);
+    @Nested
+    class ScalarSet {
 
-      byteOps.setInt(bytes, 0, 0x0102_0304);
+      @Test
+      void setInt() {
+        T bytes = getBytes(new byte[4]);
 
-      assertEquals(0x02, byteOps.getByte(bytes, 0));
-      assertEquals(0x01, byteOps.getByte(bytes, 1));
-      assertEquals(0x04, byteOps.getByte(bytes, 2));
-      assertEquals(0x03, byteOps.getByte(bytes, 3));
-      assertEquals(0x0102_0304, byteOps.getInt(bytes, 0));
+        byteOps.setInt(bytes, 0, 0x0102_0304);
+
+        assertEquals(0x02, byteOps.getByte(bytes, 0));
+        assertEquals(0x01, byteOps.getByte(bytes, 1));
+        assertEquals(0x04, byteOps.getByte(bytes, 2));
+        assertEquals(0x03, byteOps.getByte(bytes, 3));
+        assertEquals(0x0102_0304, byteOps.getInt(bytes, 0));
+      }
+
+      @Test
+      void setLong() {
+        T bytes = getBytes(new byte[8]);
+
+        byteOps.setLong(bytes, 0, 0x0102_0304_0506_0708L);
+
+        assertEquals(0x02, byteOps.getByte(bytes, 0));
+        assertEquals(0x01, byteOps.getByte(bytes, 1));
+        assertEquals(0x04, byteOps.getByte(bytes, 2));
+        assertEquals(0x03, byteOps.getByte(bytes, 3));
+        assertEquals(0x06, byteOps.getByte(bytes, 4));
+        assertEquals(0x05, byteOps.getByte(bytes, 5));
+        assertEquals(0x08, byteOps.getByte(bytes, 6));
+        assertEquals(0x07, byteOps.getByte(bytes, 7));
+      }
+
+      @Test
+      void setFloat() {
+        T bytes = getBytes(new byte[4]);
+
+        byteOps.setFloat(bytes, 0, Float.intBitsToFloat(0x3F80_0000));
+
+        assertEquals((byte) 0x80, byteOps.getByte(bytes, 0));
+        assertEquals(0x3F, byteOps.getByte(bytes, 1));
+        assertEquals(0x00, byteOps.getByte(bytes, 2));
+        assertEquals(0x00, byteOps.getByte(bytes, 3));
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), byteOps.getFloat(bytes, 0));
+      }
+
+      @Test
+      void setDouble() {
+        T bytes = getBytes(new byte[8]);
+
+        byteOps.setDouble(bytes, 0, Double.longBitsToDouble(0x3FF0_0000_0000_0000L));
+
+        assertEquals((byte) 0xF0, byteOps.getByte(bytes, 0));
+        assertEquals(0x3F, byteOps.getByte(bytes, 1));
+        assertEquals(0x00, byteOps.getByte(bytes, 2));
+        assertEquals(0x00, byteOps.getByte(bytes, 3));
+        assertEquals(0x00, byteOps.getByte(bytes, 4));
+        assertEquals(0x00, byteOps.getByte(bytes, 5));
+        assertEquals(0x00, byteOps.getByte(bytes, 6));
+        assertEquals(0x00, byteOps.getByte(bytes, 7));
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), byteOps.getDouble(bytes, 0));
+      }
     }
 
-    @Test
-    void getLong() {
-      T bytes = getBytes(new byte[]{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
+    @Nested
+    class ArrayGet {
 
-      long l = byteOps.getLong(bytes, 0);
+      @Test
+      void getIntArray() {
+        T bytes = getBytes(new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07});
 
-      assertEquals(0x0100_0302_0504_0706L, l);
+        int[] is = byteOps.getIntArray(bytes, 0, 2);
+
+        assertEquals(0x0100_0302, is[0]);
+        assertEquals(0x0504_0706, is[1]);
+        assertArrayEquals(new int[] {0x0100_0302, 0x0504_0706}, is);
+      }
+
+      @Test
+      void getLongArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                  0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F
+                });
+
+        long[] ls = byteOps.getLongArray(bytes, 0, 2);
+
+        assertEquals(0x0100_0302_0504_0706L, ls[0]);
+        assertEquals(0x0908_0B0A_0D0C_0F0EL, ls[1]);
+        assertArrayEquals(new long[] {0x0100_0302_0504_0706L, 0x0908_0B0A_0D0C_0F0EL}, ls);
+      }
+
+      @Test
+      void getFloatArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x00, 0x00, (byte) 0x80, 0x3F,
+                  0x00, 0x00, (byte) 0x80, 0x3F
+                });
+
+        float[] fs = byteOps.getFloatArray(bytes, 0, 2);
+
+        assertEquals(Float.intBitsToFloat(0x0000_3F80), fs[0]);
+        assertEquals(Float.intBitsToFloat(0x0000_3F80), fs[1]);
+        assertArrayEquals(
+            new float[] {Float.intBitsToFloat(0x0000_3F80), Float.intBitsToFloat(0x0000_3F80)}, fs);
+      }
+
+      @Test
+      void getDoubleArray() {
+        T bytes =
+            getBytes(
+                new byte[] {
+                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xF0, 0x3F,
+                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xF0, 0x3F
+                });
+
+        double[] ds = byteOps.getDoubleArray(bytes, 0, 2);
+
+        assertEquals(Double.longBitsToDouble(0x0000_0000_0000_3FF0L), ds[0]);
+        assertEquals(Double.longBitsToDouble(0x0000_0000_0000_3FF0L), ds[1]);
+        assertArrayEquals(
+            new double[] {
+              Double.longBitsToDouble(0x0000_0000_0000_3FF0L),
+              Double.longBitsToDouble(0x0000_0000_0000_3FF0L)
+            },
+            ds);
+      }
     }
 
-    @Test
-    void setLong() {
-      T bytes = getBytes(new byte[8]);
+    @Nested
+    class ArraySet {
 
-      byteOps.setLong(bytes, 0, 0x0102_0304_0506_0708L);
+      @Test
+      void setIntArray() {
+        T bytes = getBytes(new byte[8]);
 
-      assertEquals(0x02, byteOps.getByte(bytes, 0));
-      assertEquals(0x01, byteOps.getByte(bytes, 1));
-      assertEquals(0x04, byteOps.getByte(bytes, 2));
-      assertEquals(0x03, byteOps.getByte(bytes, 3));
-      assertEquals(0x06, byteOps.getByte(bytes, 4));
-      assertEquals(0x05, byteOps.getByte(bytes, 5));
-      assertEquals(0x08, byteOps.getByte(bytes, 6));
-      assertEquals(0x07, byteOps.getByte(bytes, 7));
+        byteOps.setIntArray(bytes, 0, new int[] {0x0102_0304, 0x0506_0708});
+
+        assertEquals(0x02, byteOps.getByte(bytes, 0));
+        assertEquals(0x01, byteOps.getByte(bytes, 1));
+        assertEquals(0x04, byteOps.getByte(bytes, 2));
+        assertEquals(0x03, byteOps.getByte(bytes, 3));
+        assertEquals(0x06, byteOps.getByte(bytes, 4));
+        assertEquals(0x05, byteOps.getByte(bytes, 5));
+        assertEquals(0x08, byteOps.getByte(bytes, 6));
+        assertEquals(0x07, byteOps.getByte(bytes, 7));
+        assertEquals(0x0102_0304, byteOps.getInt(bytes, 0));
+        assertEquals(0x0506_0708, byteOps.getInt(bytes, 4));
+        assertArrayEquals(new int[] {0x0102_0304, 0x0506_0708}, byteOps.getIntArray(bytes, 0, 2));
+      }
+
+      @Test
+      void setLongArray() {
+        T bytes = getBytes(new byte[16]);
+
+        byteOps.setLongArray(bytes, 0, new long[] {0x0102_0304_0506_0708L, 0x090A_0B0C_0D0E_0F10L});
+
+        assertEquals(0x02, byteOps.getByte(bytes, 0));
+        assertEquals(0x01, byteOps.getByte(bytes, 1));
+        assertEquals(0x04, byteOps.getByte(bytes, 2));
+        assertEquals(0x03, byteOps.getByte(bytes, 3));
+        assertEquals(0x06, byteOps.getByte(bytes, 4));
+        assertEquals(0x05, byteOps.getByte(bytes, 5));
+        assertEquals(0x08, byteOps.getByte(bytes, 6));
+        assertEquals(0x07, byteOps.getByte(bytes, 7));
+        assertEquals(0x0A, byteOps.getByte(bytes, 8));
+        assertEquals(0x09, byteOps.getByte(bytes, 9));
+        assertEquals(0x0C, byteOps.getByte(bytes, 10));
+        assertEquals(0x0B, byteOps.getByte(bytes, 11));
+        assertEquals(0x0E, byteOps.getByte(bytes, 12));
+        assertEquals(0x0D, byteOps.getByte(bytes, 13));
+        assertEquals(0x10, byteOps.getByte(bytes, 14));
+        assertEquals(0x0F, byteOps.getByte(bytes, 15));
+        assertEquals(0x0102_0304_0506_0708L, byteOps.getLong(bytes, 0));
+        assertEquals(0x090A_0B0C_0D0E_0F10L, byteOps.getLong(bytes, 8));
+        assertArrayEquals(
+            new long[] {0x0102_0304_0506_0708L, 0x090A_0B0C_0D0E_0F10L},
+            byteOps.getLongArray(bytes, 0, 2));
+      }
+
+      @Test
+      void setFloatArray() {
+        T bytes = getBytes(new byte[8]);
+
+        byteOps.setFloatArray(
+            bytes,
+            0,
+            new float[] {Float.intBitsToFloat(0x3F80_0000), Float.intBitsToFloat(0x4000_0000)});
+
+        assertEquals((byte) 0x80, byteOps.getByte(bytes, 0));
+        assertEquals(0x3F, byteOps.getByte(bytes, 1));
+        assertEquals(0x00, byteOps.getByte(bytes, 2));
+        assertEquals(0x00, byteOps.getByte(bytes, 3));
+        assertEquals(0x00, byteOps.getByte(bytes, 4));
+        assertEquals(0x40, byteOps.getByte(bytes, 5));
+        assertEquals(0x00, byteOps.getByte(bytes, 6));
+        assertEquals(0x00, byteOps.getByte(bytes, 7));
+        assertEquals(Float.intBitsToFloat(0x3F80_0000), byteOps.getFloat(bytes, 0));
+        assertEquals(Float.intBitsToFloat(0x4000_0000), byteOps.getFloat(bytes, 4));
+        assertArrayEquals(
+            new float[] {Float.intBitsToFloat(0x3F80_0000), Float.intBitsToFloat(0x4000_0000)},
+            byteOps.getFloatArray(bytes, 0, 2));
+      }
+
+      @Test
+      void setDoubleArray() {
+        T bytes = getBytes(new byte[16]);
+
+        byteOps.setDoubleArray(
+            bytes,
+            0,
+            new double[] {
+              Double.longBitsToDouble(0x3FF0_0000_0000_0000L),
+              Double.longBitsToDouble(0x4000_0000_0000_0000L)
+            });
+
+        assertEquals((byte) 0xF0, byteOps.getByte(bytes, 0));
+        assertEquals(0x3F, byteOps.getByte(bytes, 1));
+        assertEquals(0x00, byteOps.getByte(bytes, 2));
+        assertEquals(0x00, byteOps.getByte(bytes, 3));
+        assertEquals(0x00, byteOps.getByte(bytes, 4));
+        assertEquals(0x00, byteOps.getByte(bytes, 5));
+        assertEquals(0x00, byteOps.getByte(bytes, 6));
+        assertEquals(0x00, byteOps.getByte(bytes, 7));
+        assertEquals(0x00, byteOps.getByte(bytes, 8));
+        assertEquals(0x40, byteOps.getByte(bytes, 9));
+        assertEquals(0x00, byteOps.getByte(bytes, 10));
+        assertEquals(0x00, byteOps.getByte(bytes, 11));
+        assertEquals(0x00, byteOps.getByte(bytes, 12));
+        assertEquals(0x00, byteOps.getByte(bytes, 13));
+        assertEquals(0x00, byteOps.getByte(bytes, 14));
+        assertEquals(0x00, byteOps.getByte(bytes, 15));
+        assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), byteOps.getDouble(bytes, 0));
+        assertEquals(Double.longBitsToDouble(0x4000_0000_0000_0000L), byteOps.getDouble(bytes, 8));
+        assertArrayEquals(
+            new double[] {
+              Double.longBitsToDouble(0x3FF0_0000_0000_0000L),
+              Double.longBitsToDouble(0x4000_0000_0000_0000L)
+            },
+            byteOps.getDoubleArray(bytes, 0, 2));
+      }
     }
-
-    @Test
-    void getFloat() {
-      T bytes = getBytes(new byte[]{0x00, 0x00, (byte) 0x80, 0x3F});
-
-      float f = byteOps.getFloat(bytes, 0);
-
-      assertEquals(Float.intBitsToFloat(0x0000_3F80), f);
-    }
-
-    @Test
-    void setFloat() {
-      T bytes = getBytes(new byte[4]);
-
-      byteOps.setFloat(bytes, 0, Float.intBitsToFloat(0x3F80_0000));
-
-      assertEquals((byte) 0x80, byteOps.getByte(bytes, 0));
-      assertEquals(0x3F, byteOps.getByte(bytes, 1));
-      assertEquals(0x00, byteOps.getByte(bytes, 2));
-      assertEquals(0x00, byteOps.getByte(bytes, 3));
-      assertEquals(Float.intBitsToFloat(0x3F80_0000), byteOps.getFloat(bytes, 0));
-    }
-
-    @Test
-    void getDouble() {
-      T bytes = getBytes(new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xF0, 0x3F});
-
-      double d = byteOps.getDouble(bytes, 0);
-
-      assertEquals(Double.longBitsToDouble(0x0000_0000_0000_3FF0L), d);
-    }
-
-    @Test
-    void setDouble() {
-      T bytes = getBytes(new byte[8]);
-
-      byteOps.setDouble(bytes, 0, Double.longBitsToDouble(0x3FF0_0000_0000_0000L));
-
-      assertEquals((byte) 0xF0, byteOps.getByte(bytes, 0));
-      assertEquals(0x3F, byteOps.getByte(bytes, 1));
-      assertEquals(0x00, byteOps.getByte(bytes, 2));
-      assertEquals(0x00, byteOps.getByte(bytes, 3));
-      assertEquals(0x00, byteOps.getByte(bytes, 4));
-      assertEquals(0x00, byteOps.getByte(bytes, 5));
-      assertEquals(0x00, byteOps.getByte(bytes, 6));
-      assertEquals(0x00, byteOps.getByte(bytes, 7));
-      assertEquals(Double.longBitsToDouble(0x3FF0_0000_0000_0000L), byteOps.getDouble(bytes, 0));
-    }
-
   }
-
-
 }


### PR DESCRIPTION
Adds methods for getting and setting array values.

Get
---
- `ByteOps::getBooleanArray`
- `ByteOps::getByteArray`
- `ByteOps::getShortArray`
- `ByteOps::getIntArray`
- `ByteOps::getLongArray`
- `ByteOps::getFloatArray`
- `ByteOps::getDoubleArray`

Set
---
- `ByteOps::setBooleanArray`
- `ByteOps::setByteArray`
- `ByteOps::setShortArray`
- `ByteOps::setIntArray`
- `ByteOps::setLongArray`
- `ByteOps::setFloatArray`
- `ByteOps::setDoubleArray`